### PR TITLE
Use scope with serialize

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,16 @@ type Options = {
   strict: boolean
 }
 
-function serialize(item: any, scope: Object): string {
+function getClassNamespace(className: string, scope: Object) {
+  for (const key in scope) {
+    if ({}.hasOwnProperty.call(scope, key) && scope[key].name === className) {
+      return key
+    }
+  }
+  return className
+}
+
+function serialize(item: any, scope: Object = {}): string {
   const type = typeof item
   if (item === null) {
     return 'N;'
@@ -53,7 +62,7 @@ function serialize(item: any, scope: Object): string {
   }
   const items = []
   const constructorName = getClassNamespace(item.constructor.name, scope)
-  const constructorNameLength = item.__PHP_Incomplete_Class_Name || constructorName.length
+  const constructorNameLength = constructorName.length
   for (const key in item) {
     if ({}.hasOwnProperty.call(item, key) && typeof item[key] !== 'function') {
       const value = item[key]
@@ -178,14 +187,7 @@ function unserializeItem(item: Buffer, startIndex: number, scope: Object, option
   throw new SyntaxError()
 }
 
-function getClassNamespace(className: string, scope: Object) {
-  for (const key in scope) {
-    if (scope[key].name === className) {
-      return key
-    }
-  }
-  return className
-}
+
 
 function getClassReference(className: string, scope: Object, strict: boolean): Object {
   let container

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ type Options = {
   strict: boolean
 }
 
-function serialize(item: any): string {
+function serialize(item: any, scope: Object): string {
   const type = typeof item
   if (item === null) {
     return 'N;'
@@ -47,11 +47,13 @@ function serialize(item: any): string {
   }
   if (typeof item.serialize === 'function') {
     const serialized = item.serialize()
+    const constructorName = getClassNamespace(item.constructor.name, scope)
     assert(typeof serialized === 'string', `${item.constructor.name}.serialize should return a string`)
-    return `C:${item.constructor.name.length}:"${item.constructor.name}":${serialized.length}:{${serialized}}`
+    return `C:${constructorName.length}:"${constructorName}":${serialized.length}:{${serialized}}`
   }
   const items = []
-  const constructorName = item.__PHP_Incomplete_Class_Name || item.constructor.name.length
+  const constructorName = getClassNamespace(item.constructor.name, scope)
+  const constructorNameLength = item.__PHP_Incomplete_Class_Name || constructorName.length
   for (const key in item) {
     if ({}.hasOwnProperty.call(item, key) && typeof item[key] !== 'function') {
       const value = item[key]
@@ -59,7 +61,7 @@ function serialize(item: any): string {
       items.push(serialize(value))
     }
   }
-  return `O:${constructorName}:"${item.constructor.name}":${items.length / 2}:{${items.join('')}}`
+  return `O:${constructorNameLength}:"${constructorName}":${items.length / 2}:{${items.join('')}}`
 }
 
 function unserializeItem(item: Buffer, startIndex: number, scope: Object, options: Options): { index: number, value: any } {
@@ -174,6 +176,15 @@ function unserializeItem(item: Buffer, startIndex: number, scope: Object, option
     return { index: currentIndex, value: container }
   }
   throw new SyntaxError()
+}
+
+function getClassNamespace(className: string, scope: Object) {
+  for (const key in scope) {
+    if (scope[key].name === className) {
+      return key
+    }
+  }
+  return className
 }
 
 function getClassReference(className: string, scope: Object, strict: boolean): Object {


### PR DESCRIPTION
I need to serialize classes with namespaces, so i pass scope as argument on serialize function to search for the namespace of the class.

```
class Test {
    constructor(a, b) {
        this.a = a;
        this.b = b;
    }
}
let job = new Test(1, 2);

let str = serialize (job, {
        'App\\Test': Test
})
console.log(str) // C:8:"App\Test":13:{s:1:"a";i:1;s:1:"b";i:2;}

```