### PR TITLE
Big Numbers serialization fix with isSafeInteger.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ function serialize(item: any, scope: Object = {}): string {
     return 'N;'
   }
   if (type === 'number') {
-    if (item % 1 === 0) {
+    if (Number.isSafeInteger(item)) {
       return `i:${item};`
     }
     return `d:${item};`


### PR DESCRIPTION
Allows to correctly serialize/deserialize big Number values like Number.MAX_VALUE.
Kind of update for https://github.com/steelbrain/php-serialize/pull/67