### PR TITLE
Pass scope for serialize nested objects

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,8 +65,8 @@ function serialize(item: any, scope: Object = {}): string {
   for (const key in item) {
     if ({}.hasOwnProperty.call(item, key) && typeof item[key] !== 'function') {
       const value = item[key]
-      items.push(serialize(key))
-      items.push(serialize(value))
+      items.push(serialize(key, scope))
+      items.push(serialize(value, scope))
     }
   }
   return `O:${constructorName.length}:"${constructorName}":${items.length / 2}:{${items.join('')}}`


### PR DESCRIPTION
I added missing scope param for properly cast class names while serialization js object.

I provide it to my application, but I didn't run tests in your repo. Please check this fix and add to npm repository compiled version.