### PR TITLE
Fixes bug: handling of shallow arrays

### DIFF
--- a/spec/serialize.js
+++ b/spec/serialize.js
@@ -43,6 +43,7 @@ function serializeForTests() {
   debug(new DeepUser(), {
     'Deep\\User': DeepUser,
   })
+  debug((() => {let arr = []; arr[0] = 'shallow'; arr[4] = 'array'; return arr})());
 
   return items
 }

--- a/spec/serialize.php
+++ b/spec/serialize.php
@@ -42,3 +42,4 @@ debug(new Test());
 debug(new TestTwo());
 debug(new TestParent());
 require('serialize-namespaces.php');
+debug(array(0 => "shallow", 4 => "array"));

--- a/spec/serialize.php.out
+++ b/spec/serialize.php.out
@@ -14,3 +14,4 @@ C:4:"Test":3:{asd}
 O:7:"TestTwo":1:{s:4:"test";s:2:"hi";}
 C:10:"TestParent":70:{a:2:{i:0;C:4:"Test":3:{asd}i:1;O:7:"TestTwo":1:{s:4:"test";s:2:"hi";}}}
 O:9:"Deep\User":0:{}
+a:2:{i:0;s:7:"shallow";i:4;s:5:"array";}

--- a/src/serialize.js
+++ b/src/serialize.js
@@ -13,7 +13,7 @@ function serializeObject(item: Object, scope: Object): string {
   const processed = Array.isArray(item)
     ? item.map((value, index) => `${serialize(index, scope)}${serialize(value, scope)}`)
     : Object.keys(item).map(key => `${serialize(key, scope)}${serialize(item[key], scope)}`)
-  return `${processed.length}:{${processed.join('')}}`
+  return `${processed.filter(e => e !== undefined).length}:{${processed.join('')}}`
 }
 
 export default function serialize(item: any, scope: Object = {}, givenOptions: Object = {}): string {


### PR DESCRIPTION
This pull request fixes the following bug:

In PHP, serializing shallow arrays does not count null items:
```
assert(serialize(array(0 => 'shallow', 4 => 'array')) == 'a:2:{i:0;s:7:"shallow";i:4;s:5:"array";}')
```

Serialize the same array with this module, what happened before is:
```
const { serialize } = require('php-serialize');
let arr = [];
arr[0] = 'shallow';
arr[4] = 'array';
console.log(serialize(arr));      // == 'a:5:{i:0;s:7:"shallow";i:4;s:5:"array";}'
```

This is wrong, and trying to unserialize the value fails as well:
```
> x.unserialize('a:5:{i:0;s:7:"shallow";i:4;s:5:"array";}')
Error: Unknown type at index 41 while unserializing payload
    at Parser.error (/home/neo/Documents/php-serialize/lib/parser.js:35:12)
    at Parser.getType (/home/neo/Documents/php-serialize/lib/parser.js:80:18)
    at unserializeItem (/home/neo/Documents/php-serialize/lib/unserialize.js:54:23)
    at unserializePairs (/home/neo/Documents/php-serialize/lib/unserialize.js:36:17)
    at parser.getByLength.length (/home/neo/Documents/php-serialize/lib/unserialize.js:75:58)
    at Parser.getByLength (/home/neo/Documents/php-serialize/lib/parser.js:103:20)
    at unserializeItem (/home/neo/Documents/php-serialize/lib/unserialize.js:75:26)
    at Object.unserialize (/home/neo/Documents/php-serialize/lib/unserialize.js:130:10)
```

---

The proposed fix ignores `undefined` elements of the array when calculating its length. An extra test has been added as well.
