### PR TITLE
Fix serialization of Map with multiple elements

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -51,7 +51,7 @@ export default function serialize(
   if (item instanceof Map) {
     return `a:${item.size}:{${Array.from(item.entries()).map(([key, value]) => {
       return `${serialize(key, scope)}${serialize(value, scope)}`
-    })}}`
+    }).join('')}}`
   }
 
   const constructorName = getClassNamespace(item, scope)

--- a/test/serialize.php
+++ b/test/serialize.php
@@ -44,3 +44,4 @@ debug(new TestParent());
 require('serialize-namespaces.php');
 debug(array(0 => "shallow", 4 => "array"));
 debug(array(1 => "q"));
+debug(array(1 => "1", 2 => "2"));

--- a/test/serialize.php.out
+++ b/test/serialize.php.out
@@ -16,3 +16,4 @@ C:10:"TestParent":70:{a:2:{i:0;C:4:"Test":3:{asd}i:1;O:7:"TestTwo":1:{s:4:"test"
 O:9:"Deep\User":0:{}
 a:2:{i:0;s:7:"shallow";i:4;s:5:"array";}
 a:1:{i:1;s:1:"q";}
+a:2:{i:1;s:1:"1";i:2;s:1:"2";}

--- a/test/serialize.ts
+++ b/test/serialize.ts
@@ -53,6 +53,7 @@ function serializeForTests() {
     })(),
   )
   debug(new Map([[1, 'q']]))
+  debug(new Map([[1, '1'], [2, '2']]))
 
   return items
 }


### PR DESCRIPTION
Please take a look and release a new fixed version. Thank you 🙂 

I just tried in my project. It seems we need an extra `.join('')` because I am getting `Invalid serialized array format. Got: "a:2:{i:71654;i:61298;,i:71655;i:61299;}"` when there is more than 1 element in the array. I see the test is testing only the case with the one item in the array but for 2+ items there it fails because of extra `,`.