### PR TITLE
Remove usage of `assert.invariant`

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -30,3 +30,14 @@ export function getClass(prototype: Record<string, any>) {
   PhpClass.prototype = prototype
   return PhpClass
 }
+
+/**
+ * Ensures that the given {@link value} is truthy, throws an {@link Error} otherwise.
+ * @param value the value to check to be truthy.
+ * @param message the message of the {@link Error} if the value is falsy.
+ */
+export function invariant(value: any, message?: string) {
+  if (!value) {
+    throw new Error(message)
+  }
+}

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -1,5 +1,4 @@
-import invariant from 'assert'
-import { isInteger, getByteLength } from './helpers'
+import { isInteger, getByteLength, invariant } from './helpers'
 
 function getClassNamespace(item: any, scope: Record<string, any>) {
   return (

--- a/src/unserialize.ts
+++ b/src/unserialize.ts
@@ -1,7 +1,6 @@
-import invariant from 'assert'
 // eslint-disable-next-line import/no-cycle
 import Parser from './parser'
-import { isInteger, getClass, getIncompleteClass, __PHP_Incomplete_Class } from './helpers'
+import { isInteger, getClass, getIncompleteClass, __PHP_Incomplete_Class, invariant } from './helpers'
 
 export type Options = {
   strict: boolean


### PR DESCRIPTION
I was using `php-serialize` at client level using Svelte and Vite, when it warned me at build time:

```
[plugin:vite:resolve] Module "assert" has been externalized for browser compatibility, imported by "/home/elian/Projects/toolkit/node_modules/php-serialize/lib/esm/unserialize.js". See http://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
```

Apparently this is due to the fact that `assert` is a Node module, so it has to embed this module to work in the browser.

I've looked at the uses of `invariant` in the code base and they are only a few, so I thought about replacing them with simple guard statements instead.